### PR TITLE
Fixed FreeRTOS include path

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "flags": [
       "-I CMSIS/RTOS2/FreeRTOS/Include",
       "-I CMSIS/RTOS2/FreeRTOS/Include1",
-      "-I Source/Include",
+      "-I Source/include",
       "-I PlatformIO"
     ],
     "extraScript": "library.py",


### PR DESCRIPTION
Capital "I" caused a problem on Linux. Build process couldn't find FreeRTOS.h.